### PR TITLE
Fix -d description

### DIFF
--- a/iisGeolocate/Program.cs
+++ b/iisGeolocate/Program.cs
@@ -35,7 +35,7 @@ internal class Program
 
         var dOpt = new Option<string>("-d")
         {
-            Description = "Directory to recursively process. Either this or -f is required"
+            Description = "Directory to recursively process for IIS logs. This will be searched for *.log files"
         };
         
         var csvOpt = new Option<string>(


### PR DESCRIPTION
This removes mention of -f as it does not exist for this program also adds context that *.log files are needed to be present from the original message 